### PR TITLE
LEXEVS-3135 Updated LexEVS Remote API HTML Landing page wiki links to 6.5 projects.

### DIFF
--- a/SDK4_1_1/system/web/index.html
+++ b/SDK4_1_1/system/web/index.html
@@ -15,24 +15,24 @@
         <p>This is the landing page for the LexEVS Java RMI.</p>
         <p>Java remote method invocation application interfaces are available here.</p>
         <p> Click through for further instructions as to how to access these API's.</p>
-        <h2><a  href="https://wiki.nci.nih.gov/display/LexEVS/LexEVS">Go To The Wiki Docs</a></h2>
+        <h2><a  href="https://wiki.nci.nih.gov/x/OJG4Aw">Go To The Wiki Docs</a></h2>
     </div>
 	
     <div >
         <div >
-            <h3><a href="https://wiki.nci.nih.gov/display/LexEVS/LexEVS+6.x+Documentation" target="_blank">LexEVS</a></h3>
+            <h3><a href="https://wiki.nci.nih.gov/x/mpG4Aw" target="_blank">LexEVS</a></h3>
             <p>Middleware for an enterprise level terminology service that is closely aligned with terminology service standards.</p>
 
-            <h3><a href="https://wiki.nci.nih.gov/display/LexEVS/2+-+LexEVS+6.x+Data+Service+APIs" target="_blank">Distributed API</a></h3>
+            <h3><a href="https://wiki.nci.nih.gov/x/65C4Aw" target="_blank">Distributed API</a></h3>
             <p>An API available to users as a Java Remote Method Invocation service.</p>
 
         </div>
 
         <div >
-            <h3><a href="https://wiki.nci.nih.gov/display/LexEVS/LexEVS+6.5.0+Installation+Options" target="_blank">Distributed Client</a></h3>
+            <h3><a href="https://wiki.nci.nih.gov/x/DoOaF#LexEVS6.5.0InstallationOptions-LexEVSDistributedClient" target="_blank">Distributed Client</a></h3>
             <p>A ready to use Java client with example method calls run from an Ant build.</p>
 
-            <h3><a href="https://wiki.nci.nih.gov/display/LexEVS/LexEVS+6.x+CTS2" target="_blank">Ancillary services</a></h3>
+            <h3><a href="https://wiki.nci.nih.gov/x/-4GCCg" target="_blank">Ancillary services</a></h3>
             <p>See more about related services such as CTS2 standard REST implementations.</p>
             <h3><a href="https://github.com/lexevs/lexevs-remote/issues" target="_blank" >Contact</a></h3>
         </div>

--- a/SDK4_1_1/system/web/index.html
+++ b/SDK4_1_1/system/web/index.html
@@ -23,20 +23,19 @@
             <h3><a href="https://wiki.nci.nih.gov/display/LexEVS/LexEVS+6.x+Documentation" target="_blank">LexEVS</a></h3>
             <p>Middleware for an enterprise level terminology service that is closely aligned with terminology service standards.</p>
 
-            <h3><a href="https://wiki.nci.nih.gov/display/LexEVS/2+-+LexEVS+6.x+caCORE+Data+Service+API#id-2-LexEVS6xcaCOREDataServiceAPI-LexEVSDistributed" target="_blank">Distributed API</a></h3>
+            <h3><a href="https://wiki.nci.nih.gov/display/LexEVS/2+-+LexEVS+6.x+Data+Service+APIs" target="_blank">Distributed API</a></h3>
             <p>An API available to users as a Java Remote Method Invocation service.</p>
 
         </div>
 
         <div >
-            <h3><a href="https://wiki.nci.nih.gov/display/LexEVS/LexEVS+6.1+Installation+Options#LexEVS61InstallationOptions-LexEVSDistributedClient" target="_blank">Distributed Client</a></h3>
+            <h3><a href="https://wiki.nci.nih.gov/display/LexEVS/LexEVS+6.5.0+Installation+Options" target="_blank">Distributed Client</a></h3>
             <p>A ready to use Java client with example method calls run from an Ant build.</p>
 
             <h3><a href="https://wiki.nci.nih.gov/display/LexEVS/LexEVS+6.x+CTS2" target="_blank">Ancillary services</a></h3>
             <p>See more about related services such as CTS2 standard REST implementations.</p>
             <h3><a href="https://github.com/lexevs/lexevs-remote/issues" target="_blank" >Contact</a></h3>
         </div>
-  
 
     <div>
         <img src="images/footer_nci.gif" alt="National Cancer Institute">


### PR DESCRIPTION
LEXEVS-3135 Updated LexEVS Remote API HTML Landing page wiki links to 6.5 projects.
Updated corresponding wiki page: https://wiki.nci.nih.gov/display/LexEVS/2+-+LexEVS+6.x+Data+Service+APIs