### PR TITLE
LEXEVS-4616 Updated test method testIsReverseName() to test for valid reverse name "equivalentProperty".

### DIFF
--- a/LexEVSService/test/src/org/LexGrid/LexBIG/distributed/test/services/LexBIGServiceConvenienceMethodsTest.java
+++ b/LexEVSService/test/src/org/LexGrid/LexBIG/distributed/test/services/LexBIGServiceConvenienceMethodsTest.java
@@ -149,7 +149,7 @@ public class LexBIGServiceConvenienceMethodsTest extends ServiceTestCase {
 		boolean badReverseName = lbscm.isReverseName(THES_SCHEME, csvt, "instance");
 		assertFalse(badReverseName);
 		
-		boolean goodReverseName = lbscm.isReverseName(THES_SCHEME, csvt, "AllDifferent");
+		boolean goodReverseName = lbscm.isReverseName(THES_SCHEME, csvt, "equivalentProperty");
 		assertTrue(goodReverseName);
 	}
 }


### PR DESCRIPTION
LEXEVS-4616 Updated test method testIsReverseName() to test for valid reverse name "equivalentProperty".